### PR TITLE
[fix] Do not load .gitkeep file as card image file.

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,10 @@ const shuffle = (array) => {
 
 const loadImages = (imagePath) => {
     const cardImgDirents = fs.readdirSync(imagePath, { withFileTypes: true });
-    return cardImgDirents.filter(dirent => dirent.isFile()).map(({ name }) => name);
+    const cardImgNames = cardImgDirents.filter(
+        dirent => dirent.isFile() && dirent.name != '.gitkeep'
+    ).map(({ name }) => name);
+    return cardImgNames
 }
 
 // タワー構築


### PR DESCRIPTION
# 概要
- [6fe7875](https://github.com/saburo81/tower/commit/6fe7875cd810b2984ff1fcaeb3a919778ce854e4)にて作成したカード画像置き場の.gitkeepがカード画像としてロードされることによるバグを修正